### PR TITLE
Fix deduplication across mirrored calendar UIDs and bump to v0.2.2

### DIFF
--- a/custom_components/calendar_merge/calendar.py
+++ b/custom_components/calendar_merge/calendar.py
@@ -67,7 +67,7 @@ def _to_datetime(value: datetime | date) -> datetime:
     )
 
 
-def _normalize_start(start: "datetime | date") -> str:
+def _normalize_when(value: "datetime | date") -> str:
     """
     Produce a stable, timezone-independent string from an event start value.
 
@@ -84,30 +84,34 @@ def _normalize_start(start: "datetime | date") -> str:
       - Timed events: convert to UTC, truncate to minute precision to absorb
         any second-level drift between sources.
     """
-    if isinstance(start, datetime):
-        if start.tzinfo is None:
-            start = dt_util.as_local(start)
-        utc = dt_util.as_utc(start)
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = dt_util.as_local(value)
+        utc = dt_util.as_utc(value)
         return utc.strftime("%Y-%m-%dT%H:%M")
-    return start.isoformat()
+    return value.isoformat()
 
 
 def _dedup_key(event: CalendarEvent) -> str:
     """
     Return a stable deduplication key for an event.
 
-    Priority:
-      1. UID (most reliable – set by calendar servers)
-      2. normalised summary + normalised start (fallback for caldav-less calendars)
+    Key strategy:
+      - normalized summary
+      - normalized start
+      - normalized end
 
     Summary is lowercased and stripped so minor capitalisation or whitespace
     differences between sources do not prevent matching.
+
+    We intentionally do not use UID as the primary key because mirrored events
+    from different calendar providers often have different UIDs while still
+    representing the same real-world event.
     """
-    if event.uid:
-        return f"uid\x00{event.uid}"
     summary = (event.summary or "").strip().lower()
-    start_str = _normalize_start(event.start)
-    return f"title_start\x00{summary}\x00{start_str}"
+    start_str = _normalize_when(event.start)
+    end_str = _normalize_when(event.end)
+    return f"summary_start_end\x00{summary}\x00{start_str}\x00{end_str}"
 
 
 def _strip_merge_description(description: str | None) -> str | None:
@@ -449,7 +453,7 @@ class MergedCalendarEntity(CalendarEntity):
         Returns (merged_event_list, source_map).
         source_map maps dedup_key → [source_entity_ids].
         """
-        seen: dict[str, tuple[CalendarEvent, list[str]]] = {}
+        seen: dict[str, tuple[CalendarEvent, list[str], set[str]]] = {}
         # Track per-source stats for diagnostics
         fetch_stats: dict[str, int | str] = {}
 
@@ -490,14 +494,18 @@ class MergedCalendarEntity(CalendarEntity):
                 key = _dedup_key(event)
                 if key in seen:
                     seen[key][1].append(entity_id)
+                    if event.uid:
+                        seen[key][2].add(event.uid)
                 else:
-                    seen[key] = (event, [entity_id])
+                    seen[key] = (event, [entity_id], {event.uid} if event.uid else set())
 
         merged_events: list[CalendarEvent] = []
         source_map: dict[str, list[str]] = {}
 
-        for key, (event, sources) in seen.items():
+        for key, (event, sources, uids) in seen.items():
             source_map[key] = sources
+            for uid in uids:
+                source_map[f"uid\x00{uid}"] = sources
             merged_events.append(_build_merged_event(event, sources))
 
         merged_events.sort(key=lambda e: _to_datetime(e.start))

--- a/custom_components/calendar_merge/manifest.json
+++ b/custom_components/calendar_merge/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "calendar_merge",
   "name": "Calendar Merge",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "documentation": "https://github.com/superdingo101/ha-calendar-merge",
   "issue_tracker": "https://github.com/superdingo101/ha-calendar-merge/issues",
   "dependencies": ["calendar"],

--- a/tests/test_calendar_merge.py
+++ b/tests/test_calendar_merge.py
@@ -273,6 +273,64 @@ def test_merge_deduplicates_by_uid_across_google_caldav_and_native(calendar_modu
     assert "calendar.homeassistant" in description
 
 
+def test_merge_deduplicates_same_event_with_different_uids(calendar_module):
+    entities = {
+        "calendar.google_work": FakeSourceCalendar(
+            [
+                CalendarEvent(
+                    uid="google-abc",
+                    summary="Soccer Practice",
+                    start=datetime(2024, 3, 12, 17, 0, tzinfo=timezone.utc),
+                    end=datetime(2024, 3, 12, 18, 0, tzinfo=timezone.utc),
+                )
+            ],
+            CalendarEntityFeature.CREATE_EVENT
+            | CalendarEntityFeature.UPDATE_EVENT
+            | CalendarEntityFeature.DELETE_EVENT,
+        ),
+        "calendar.apple_family": FakeSourceCalendar(
+            [
+                CalendarEvent(
+                    uid="caldav-xyz",
+                    summary="Soccer Practice",
+                    start=datetime(2024, 3, 12, 17, 0),
+                    end=datetime(2024, 3, 12, 18, 0),
+                )
+            ],
+            CalendarEntityFeature.CREATE_EVENT
+            | CalendarEntityFeature.UPDATE_EVENT
+            | CalendarEntityFeature.DELETE_EVENT,
+        ),
+    }
+    hass = HomeAssistant()
+    hass.data[calendar_module.CALENDAR_DOMAIN] = FakeCalendarComponent(entities)
+    merged = calendar_module.MergedCalendarEntity(
+        hass,
+        "entry-uids",
+        "Merged",
+        list(entities.keys()),
+        "calendar.google_work",
+    )
+
+    events = _run(
+        merged.async_get_events(
+            hass,
+            datetime(2024, 3, 1, tzinfo=timezone.utc),
+            datetime(2024, 3, 30, tzinfo=timezone.utc),
+        )
+    )
+
+    assert len(events) == 1
+    assert merged._source_map["uid\x00google-abc"] == [
+        "calendar.google_work",
+        "calendar.apple_family",
+    ]
+    assert merged._source_map["uid\x00caldav-xyz"] == [
+        "calendar.google_work",
+        "calendar.apple_family",
+    ]
+
+
 def test_merge_deduplicates_by_title_and_start_when_uid_missing(calendar_module):
     start_naive = datetime(2024, 2, 10, 14, 0)
     start_aware = datetime(2024, 2, 10, 14, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
### Motivation
- Mirrored events coming from different calendar providers sometimes had different `uid` values which caused the integration to create duplicate merged events.  
- Deduplication needs to match real-world events (title + time) while still preserving the ability to proxy updates/deletes back to every observed source UID.  

### Description
- Changed normalization helper name to ` _normalize_when` and unified datetime/date normalization for stable comparisons.  
- Switched deduplication key to use normalized `summary + start + end` (returned by ` _dedup_key`) instead of prioritizing `uid`.  
- Enhanced the `seen` bookkeeping to store observed source UIDs per merged key and populated `source_map` with `uid\x00{uid}` → source lists so `update`/`delete` proxying still resolves all owner calendars.  
- Added a regression test `test_merge_deduplicates_same_event_with_different_uids` that verifies events with different UIDs but identical summary/start/end are merged and their UIDs map back to the same source list.  
- Bumped integration version in `manifest.json` to `0.2.2`.  

### Testing
- Ran `pytest -q` and all tests passed: `28 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1c1528ac48331bb6b04a4c11d659b)