### PR TITLE
Add Playwright baselines PR workflow

### DIFF
--- a/.github/workflows/playwright-baselines-pr.yml
+++ b/.github/workflows/playwright-baselines-pr.yml
@@ -1,0 +1,45 @@
+name: Generate Playwright Baselines PR
+
+on:
+  workflow_dispatch:
+
+jobs:
+  generate-baselines-pr:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+
+      - run: npm ci
+
+      - run: npx playwright install --with-deps chromium
+
+      - name: Generate/update visual baselines
+        run: npx playwright test --update-snapshots
+
+      - name: Show generated snapshot changes
+        run: |
+          git status --short
+          find playwright -path "*-snapshots/*.png" -type f | sort
+
+      - name: Create or update pull request with updated baselines
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: playwright-baselines
+          delete-branch: true
+          title: Update Playwright visual baselines
+          commit-message: Add/update Playwright visual baselines
+          body: |
+            Updates Playwright visual baseline images generated in GitHub Actions.
+
+            Review the changed PNGs before merging.
+          add-paths: |
+            playwright/**/*-snapshots/*.png


### PR DESCRIPTION
### Motivation
- Provide a manual CI workflow to generate or update Playwright visual baseline images and open a pull request containing the changed PNGs so baselines can be reviewed and merged.

### Description
- Add `.github/workflows/playwright-baselines-pr.yml` which runs on `workflow_dispatch`, sets up Node 20, runs `npm ci`, installs Playwright Chromium, executes `npx playwright test --update-snapshots`, lists changed snapshots, and uses `peter-evans/create-pull-request@v7` to create/update the `playwright-baselines` branch with `playwright/**/*-snapshots/*.png`.

### Testing
- Ran inline Python assertions to validate the new workflow file contents and committed the file, and the assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fabd4312b4833180ea68ad7431fb73)